### PR TITLE
MARP-1333 Missing setup path for README_DE.md

### DIFF
--- a/db-demos-product/zip.xml
+++ b/db-demos-product/zip.xml
@@ -13,6 +13,7 @@
         <include>product.json</include>
         <include>openapi.json</include>
         <include>README.md</include>
+                <include>README_DE.md</include>
         <include>**/*.png</include>
       </includes>
     </fileSet>

--- a/db-demos-product/zip.xml
+++ b/db-demos-product/zip.xml
@@ -12,8 +12,7 @@
       <includes>
         <include>product.json</include>
         <include>openapi.json</include>
-        <include>README.md</include>
-                <include>README_DE.md</include>
+        <include>README*.md</include>
         <include>**/*.png</include>
       </includes>
     </fileSet>


### PR DESCRIPTION
Included README_DE.md in pom.xml and zip.xml